### PR TITLE
tuareg-modeでC-c hを使えるように変更

### DIFF
--- a/inits/40-ocaml.el
+++ b/inits/40-ocaml.el
@@ -1,3 +1,8 @@
 (use-package tuareg-mode
+  :defer t
   :commands (tuareg-mode tuareg-run-ocaml ocamldebug)
   :mode (("\\.ml[iylp]?" . tuareg-mode)))
+
+(eval-after-load "tuareg"
+  '(progn
+     (define-key tuareg-mode-map (kbd "C-c h") nil)))


### PR DESCRIPTION
`C-c h`が`caml-help`に割り当ててあったので無効化
