### PR TITLE
helm-descbindsを追加

### DIFF
--- a/inits/00-package.el
+++ b/inits/00-package.el
@@ -9,6 +9,7 @@
 (el-get-bundle helm-swoop)
 (el-get-bundle helm-ag)
 (el-get-bundle helm-projectile)
+(el-get-bundle helm-descbinds)
 
 ;; Git
 (el-get-bundle magit)


### PR DESCRIPTION
キーバインドの検索は頻繁には使わないので, キーバインドは割り当ててない
