### PR TITLE
シェルからパスを読み込む設定の変更

### DIFF
--- a/init.el
+++ b/init.el
@@ -3,7 +3,7 @@
   "Set up Emacs' `exec-path' and PATH environment variable to match that used by the user's shell.
 This is particularly useful under Mac OSX, where GUI apps are not started from a shell."
   (interactive)
-  (let ((path-from-shell (replace-regexp-in-string "[ \t\n]*$" "" (shell-command-to-string "$SHELL --login -i -c 'echo $PATH'"))))
+  (let ((path-from-shell (replace-regexp-in-string "[ \t\n]*$" "" (shell-command-to-string "bash --login -i -c 'echo $PATH'"))))
     (setenv "PATH" path-from-shell)
     (setq exec-path (split-string path-from-shell path-separator))))
     


### PR DESCRIPTION
`bash`からパスを読み込むように変更

`fish`からだと読み込めない理由は不明
